### PR TITLE
ci(release.yml): add commitMode as github-api to changeset publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           commit: "chore(release): version packages"
           version: node .github/changeset-version.mjs
           publish: npx changeset publish
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Enable commitMode to use GitHub API for publishing, ensuring smoother integration and reducing potential issues with direct git operations.