### PR TITLE
refactor(components): update import path for `cn` utility function

### DIFF
--- a/apps/web/src/components/copy-button.tsx
+++ b/apps/web/src/components/copy-button.tsx
@@ -3,7 +3,7 @@
 import { CheckIcon, CopyIcon } from "lucide-react";
 import React, { useEffect, useState } from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 import { Button } from "./ui/button";
 

--- a/apps/web/src/components/installation-command.tsx
+++ b/apps/web/src/components/installation-command.tsx
@@ -4,7 +4,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 const INSTALLATION_COMMAND = `npx shadcn@latest add https://chanhdai.com/r/wheel-picker.json`;
 

--- a/apps/web/src/components/mdx.tsx
+++ b/apps/web/src/components/mdx.tsx
@@ -17,9 +17,9 @@ import {
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Code, Heading } from "@/components/ui/typography";
-import { cn } from "@/lib/cn";
 import { rehypeNpmCommand } from "@/lib/rehype-npm-command";
 import { codeImport } from "@/lib/remark-code-import";
+import { cn } from "@/lib/utils";
 import type { NpmCommands } from "@/types/unist";
 
 import { CodeBlockCommand } from "./code-block-command";

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",

--- a/apps/web/src/components/ui/context-menu.tsx
+++ b/apps/web/src/components/ui/context-menu.tsx
@@ -4,7 +4,7 @@ import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 import * as React from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 function ContextMenu({
   ...props

--- a/apps/web/src/components/ui/form.tsx
+++ b/apps/web/src/components/ui/form.tsx
@@ -14,7 +14,7 @@ import {
 } from "react-hook-form";
 
 import { Label } from "@/components/ui/label";
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 const Slot = SlotPrimitive.Slot;
 

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -3,7 +3,7 @@
 import { Label as LabelPrimitive } from "radix-ui";
 import * as React from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 function Label({
   className,

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -3,7 +3,7 @@
 import { Tabs as TabsPrimitive } from "radix-ui";
 import * as React from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 function Tabs({
   className,

--- a/apps/web/src/components/ui/typography.tsx
+++ b/apps/web/src/components/ui/typography.tsx
@@ -2,7 +2,7 @@ import { LinkIcon } from "lucide-react";
 import { Slot as SlotPrimitive } from "radix-ui";
 import React from "react";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 const Slot = SlotPrimitive.Slot;
 

--- a/apps/web/src/components/wheel-picker.tsx
+++ b/apps/web/src/components/wheel-picker.tsx
@@ -2,7 +2,7 @@ import "@ncdai/react-wheel-picker/style.css";
 
 import * as WheelPickerPrimitive from "@ncdai/react-wheel-picker";
 
-import { cn } from "@/lib/cn";
+import { cn } from "@/lib/utils";
 
 type WheelPickerOption = WheelPickerPrimitive.WheelPickerOption;
 type WheelPickerClassNames = WheelPickerPrimitive.WheelPickerClassNames;
@@ -14,10 +14,10 @@ function WheelPickerWrapper({
   return (
     <WheelPickerPrimitive.WheelPickerWrapper
       className={cn(
-        "w-56 rounded-lg bg-white px-1 shadow-sm ring ring-black/5 dark:bg-zinc-900 dark:ring-white/15",
+        "w-56 rounded-lg border border-zinc-200 bg-white px-1 shadow-xs dark:border-zinc-700/80 dark:bg-zinc-900",
         "*:data-rwp:first:*:data-rwp-highlight-wrapper:rounded-s-md",
         "*:data-rwp:last:*:data-rwp-highlight-wrapper:rounded-e-md",
-        className,
+        className
       )}
       {...props}
     />

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import type { ClassValue} from "clsx";
+import type { ClassValue } from "clsx";
 import { clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 


### PR DESCRIPTION
Change import path of `cn` from "@/lib/cn" to "@/lib/utils" across multiple components to reflect the new location of the utility function. This change centralizes utility functions, improving maintainability and reducing redundancy.

feat(utils): add utility function for class name merging

Introduce a new utility function `cn` in `utils.ts` that combines `clsx` and `tailwind-merge` for efficient class name merging. This enhancement provides a more robust solution for handling conditional class names and tailwind class merging.