### PR TITLE
fix: sync selected value position when options change dynamically

### DIFF
--- a/packages/react-wheel-picker/src/index.tsx
+++ b/packages/react-wheel-picker/src/index.tsx
@@ -610,7 +610,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
   useEffect(() => {
     selectByValue(value);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, valueProp]);
+  }, [value, valueProp, options]); // selected value is changed when options are changed
 
   return (
     <div ref={containerRef} data-rwp style={{ height: containerHeight }}>


### PR DESCRIPTION
Sync selected value position when options change dynamically

- Add options to useEffect dependency array
- Ensure selectByValue is called when options change to move wheel picker to correct position
- Previously, when options changed dynamically, selected value remained at old index causing incorrect positioning