### PR TITLE
Fix/issue 65

### DIFF
--- a/.changeset/wicked-years-pick.md
+++ b/.changeset/wicked-years-pick.md
@@ -1,0 +1,5 @@
+---
+"@ncdai/react-wheel-picker": patch
+---
+
+style(react-wheel-picker): remove redundant list-style declarations and add reset styles for ul and li elements to ensure consistent styling across different browsers

--- a/packages/react-wheel-picker/src/style.css
+++ b/packages/react-wheel-picker/src/style.css
@@ -1,3 +1,14 @@
+[data-rwp-wrapper] ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-rwp-wrapper] li {
+  margin: 0;
+  padding: 0;
+}
+
 [data-rwp-wrapper] {
   position: relative;
   overflow: hidden;
@@ -36,7 +47,6 @@
 [data-rwp-highlight-list] {
   position: absolute;
   width: 100%;
-  list-style: none;
 }
 
 [data-rwp-options] {
@@ -51,7 +61,6 @@
   will-change: transform;
   backface-visibility: hidden;
   transform-style: preserve-3d;
-  list-style: none;
 }
 
 [data-rwp-option] {


### PR DESCRIPTION
style(react-wheel-picker): remove redundant list-style declarations and add reset styles for ul and li elements to ensure consistent styling across different browsers