### PR TITLE
fix(react-wheel-picker): clean up events handlers when component is unmounted

### DIFF
--- a/.changeset/big-coats-camp.md
+++ b/.changeset/big-coats-camp.md
@@ -1,0 +1,5 @@
+---
+"@ncdai/react-wheel-picker": patch
+---
+
+fix(react-wheel-picker): clean up event handlers when component is unmounted

--- a/packages/react-wheel-picker/src/index.tsx
+++ b/packages/react-wheel-picker/src/index.tsx
@@ -381,7 +381,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
   const handleDragMoveEvent = (event: MouseEvent | TouchEvent) => {
     if (
       !dragingRef.current &&
-      !containerRef.current!.contains(event.target as Node) &&
+      !containerRef.current?.contains(event.target as Node) &&
       event.target !== containerRef.current
     ) {
       return;
@@ -437,7 +437,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
     (e: MouseEvent | TouchEvent) => {
       const isDragging = dragingRef.current;
       const isTargetValid =
-        containerRef.current!.contains(e.target as Node) ||
+        !!containerRef.current?.contains(e.target as Node) ||
         e.target === containerRef.current;
 
       if ((isDragging || isTargetValid) && e.cancelable) {
@@ -546,7 +546,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
 
       const isDragging = dragingRef.current;
       const isTargetValid =
-        containerRef.current!.contains(event.target as Node) ||
+        !!containerRef.current?.contains(event.target as Node) ||
         event.target === containerRef.current;
 
       if ((isDragging || isTargetValid) && event.cancelable) {
@@ -594,10 +594,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
     const container = containerRef.current;
     if (!container) return;
 
-    const controller = new AbortController();
-    const { signal } = controller;
-
-    const opts = { signal, passive: false };
+    const opts = { passive: false };
 
     container.addEventListener("touchstart", handleDragStartEvent, opts);
     container.addEventListener("touchend", handleDragEndEvent, opts);
@@ -605,7 +602,13 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
     document.addEventListener("mousedown", handleDragStartEvent, opts);
     document.addEventListener("mouseup", handleDragEndEvent, opts);
 
-    return () => controller.abort();
+    return () => {
+      container.removeEventListener("touchstart", handleDragStartEvent);
+      container.removeEventListener("touchend", handleDragEndEvent);
+      container.removeEventListener("wheel", handleWheelEvent);
+      document.removeEventListener("mousedown", handleDragStartEvent);
+      document.removeEventListener("mouseup", handleDragEndEvent);
+    };
   }, [handleDragEndEvent, handleDragStartEvent, handleWheelEvent]);
 
   useEffect(() => {


### PR DESCRIPTION
Hi @ncdai, thank you so much for such a beautiful library! I started using it in our app recently and it works great, but unfortunately faced a weird issue in our auto test suite. It doesn't affect anything in the app, but if I understand the problem correctly - some other people using same tools might face it too so I decided to open PR. Here is my understanding below:

### Issue

When using JS DOM implementations like `jsdom` or `happy-dom` in automated testing frameworks such as `Vitest` or `Jest`, all tests in the same file share the same environment.

Because of this, event listeners attached to `document` persist between tests. When a test unmounts its React tree, `containerRef` becomes `null`, but the old listeners are still active. This leads to mouse events throwing errors in subsequent tests.

### Fix

This PR adds event handlers clean up on component unmount. And also replaces nun-null assertion with optional chaining to make handlers not to throw in case if handler is running, but the container reference is `null` for any other hypothetical reason (Not sure if it's really possible, but I suspect that it could happen in some very improbable scenarios when the component is being unmounted and the user is interacting with the app at the exact same time).
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up event listeners on unmount and made event checks null-safe to prevent errors during teardown. This stabilizes tests in JSDOM/Jest/Vitest without changing runtime behavior.

- **Bug Fixes**
  - Remove touchstart, touchend, wheel (container) and mousedown, mouseup (document) listeners on unmount to stop listeners persisting across tests.
  - Replace non-null assertions with optional chaining when checking containerRef in event handlers to avoid null-ref errors during unmount.

<!-- End of auto-generated description by cubic. -->

