### PR TITLE
docs: update README to include contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Please read the [documentation](https://react-wheel-picker.chanhdai.com/docs/get
 
 Please read the [contributing guide](/CONTRIBUTING.md).
 
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=ncdai/react-wheel-picker)](https://github.com/ncdai/react-wheel-picker/graphs/contributors)
+
+> Made with [contrib.rocks](https://contrib.rocks)
+
 ## License
 
 Licensed under the [MIT license](./LICENSE).


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a Contributors section to the README with a contrib.rocks image linking to the GitHub contributors page. Improves visibility and recognition for project contributors.

<!-- End of auto-generated description by cubic. -->

