### PR TITLE
Feat/add support for generic option and values

### DIFF
--- a/apps/web/src/components/code-tabs.tsx
+++ b/apps/web/src/components/code-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { InstallationType} from "@/hooks/use-config";
+import type { InstallationType } from "@/hooks/use-config";
 import { useConfig } from "@/hooks/use-config";
 
 import { Tabs } from "./ui/tabs";

--- a/apps/web/src/components/wheel-picker.tsx
+++ b/apps/web/src/components/wheel-picker.tsx
@@ -4,7 +4,11 @@ import * as WheelPickerPrimitive from "@ncdai/react-wheel-picker";
 
 import { cn } from "@/lib/utils";
 
-type WheelPickerOption = WheelPickerPrimitive.WheelPickerOption;
+type WheelPickerValue = WheelPickerPrimitive.WheelPickerValue;
+
+type WheelPickerOption<T extends WheelPickerValue = string> =
+  WheelPickerPrimitive.WheelPickerOption<T>;
+
 type WheelPickerClassNames = WheelPickerPrimitive.WheelPickerClassNames;
 
 function WheelPickerWrapper({
@@ -17,17 +21,17 @@ function WheelPickerWrapper({
         "w-56 rounded-lg border border-zinc-200 bg-white px-1 shadow-xs dark:border-zinc-700/80 dark:bg-zinc-900",
         "*:data-rwp:first:*:data-rwp-highlight-wrapper:rounded-s-md",
         "*:data-rwp:last:*:data-rwp-highlight-wrapper:rounded-e-md",
-        className
+        className,
       )}
       {...props}
     />
   );
 }
 
-function WheelPicker({
+function WheelPicker<T extends WheelPickerValue = string>({
   classNames,
   ...props
-}: React.ComponentProps<typeof WheelPickerPrimitive.WheelPicker>) {
+}: WheelPickerPrimitive.WheelPickerProps<T>) {
   return (
     <WheelPickerPrimitive.WheelPicker
       classNames={{

--- a/apps/web/src/content/docs/getting-started.mdx
+++ b/apps/web/src/content/docs/getting-started.mdx
@@ -278,25 +278,29 @@ Props for the `WheelPickerWrapper` component:
 
 Props for the `WheelPicker` component:
 
-| Prop                | Type                      | Default    | Description                                                     |
-| ------------------- | ------------------------- | ---------- | --------------------------------------------------------------- |
-| `options`           | `WheelPickerOption[]`     | (required) | Array of options to display in the wheel                        |
-| `value`             | `string`                  | -          | Current value of the picker (controlled mode)                   |
-| `defaultValue`      | `string`                  | -          | Default value of the picker (uncontrolled mode)                 |
-| `onValueChange`     | `(value: string) => void` | -          | Callback fired when the selected value changes                  |
-| `infinite`          | `boolean`                 | `false`    | Enable infinite scrolling                                       |
-| `visibleCount`      | `number`                  | `20`       | Number of options visible on the wheel (must be multiple of 4)  |
-| `dragSensitivity`   | `number`                  | `3`        | Sensitivity of the drag interaction (higher = more sensitive)   |
-| `scrollSensitivity` | `number`                  | `5`        | Sensitivity of the scroll interaction (higher = more sensitive) |
-| `optionItemHeight`  | `number`                  | `30`       | Height (in pixels) of each item in the picker list              |
-| `classNames`        | `WheelPickerClassNames`   | -          | Custom class names for styling                                  |
+| Prop                | Type                     | Default    | Description                                                                                        |
+| ------------------- | ------------------------ | ---------- | -------------------------------------------------------------------------------------------------- |
+| `options`           | `WheelPickerOption<T>[]` | (required) | Array of options to display in the wheel                                                           |
+| `value`             | `T`                      | -          | Current value of the picker (controlled mode). Type matches the option values (string or number)   |
+| `defaultValue`      | `T`                      | -          | Default value of the picker (uncontrolled mode). Type matches the option values (string or number) |
+| `onValueChange`     | `(value: T) => void`     | -          | Callback fired when the selected value changes. Receives the selected option's value               |
+| `infinite`          | `boolean`                | `false`    | Enable infinite scrolling                                                                          |
+| `visibleCount`      | `number`                 | `20`       | Number of options visible on the wheel (must be multiple of 4)                                     |
+| `dragSensitivity`   | `number`                 | `3`        | Sensitivity of the drag interaction (higher = more sensitive)                                      |
+| `scrollSensitivity` | `number`                 | `5`        | Sensitivity of the scroll interaction (higher = more sensitive)                                    |
+| `optionItemHeight`  | `number`                 | `30`       | Height (in pixels) of each item in the picker list                                                 |
+| `classNames`        | `WheelPickerClassNames`  | -          | Custom class names for styling                                                                     |
 
 ### Types
 
 ```tsx
-type WheelPickerOption = {
+type WheelPickerValue = string | number;
+```
+
+```tsx
+type WheelPickerOption<T extends WheelPickerValue = string> = {
   /** Value that will be returned when this option is selected */
-  value: string;
+  value: T;
   /** The content displayed for this option */
   label: ReactNode;
 };

--- a/packages/react-wheel-picker/src/index.tsx
+++ b/packages/react-wheel-picker/src/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import type {
   WheelPickerOption,
   WheelPickerProps,
+  WheelPickerValue,
   WheelPickerWrapperProps,
 } from "./types";
 import { useControllableState } from "./use-controllable-state";
@@ -32,7 +33,7 @@ const WheelPickerWrapper: React.FC<WheelPickerWrapperProps> = ({
   );
 };
 
-const WheelPicker: React.FC<WheelPickerProps> = ({
+function WheelPicker<T extends WheelPickerValue>({
   defaultValue,
   value: valueProp,
   onValueChange,
@@ -44,19 +45,19 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
   scrollSensitivity: scrollSensitivityProp = 5,
   optionItemHeight: optionHeightProp = 30,
   classNames,
-}) => {
-  const [value = optionsProp[0]?.value ?? "", setValue] = useControllableState({
+}: WheelPickerProps<T>) {
+  const [value = optionsProp[0]?.value, setValue] = useControllableState<T>({
     defaultProp: defaultValue,
     prop: valueProp,
     onChange: onValueChange,
   });
 
-  const options = useMemo<WheelPickerOption[]>(() => {
+  const options = useMemo<WheelPickerOption<T>[]>(() => {
     if (!infiniteProp) {
       return optionsProp;
     }
 
-    const result: WheelPickerOption[] = [];
+    const result: WheelPickerOption<T>[] = [];
     const halfCount = Math.ceil(countProp / 2);
 
     if (optionsProp.length === 0) {
@@ -104,7 +105,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
 
   const renderWheelItems = useMemo(() => {
     const renderItem = (
-      item: WheelPickerOption,
+      item: WheelPickerOption<T>,
       index: number,
       angle: number
     ) => (
@@ -161,7 +162,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
   ]);
 
   const renderHighlightItems = useMemo(() => {
-    const renderItem = (item: WheelPickerOption, key: React.Key) => (
+    const renderItem = (item: WheelPickerOption<T>, key: React.Key) => (
       <li
         key={key}
         className={classNames?.highlightItem}
@@ -276,7 +277,7 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
     setValue(selected.value);
   };
 
-  const selectByValue = (value: string) => {
+  const selectByValue = (value: T) => {
     const index = options.findIndex((opt) => opt.value === value);
 
     if (index === -1) {
@@ -643,7 +644,14 @@ const WheelPicker: React.FC<WheelPickerProps> = ({
       </div>
     </div>
   );
+}
+
+export {
+  WheelPicker,
+  type WheelPickerOption,
+  type WheelPickerProps,
+  type WheelPickerValue,
+  WheelPickerWrapper,
 };
 
-export { WheelPicker, type WheelPickerOption, WheelPickerWrapper };
 export { type WheelPickerClassNames } from "./types";

--- a/packages/react-wheel-picker/src/types.ts
+++ b/packages/react-wheel-picker/src/types.ts
@@ -1,11 +1,16 @@
 import type { ReactNode } from "react";
 
 /**
+ * Represents the value of a single option in the wheel picker
+ */
+export type WheelPickerValue = string | number;
+
+/**
  * Represents a single option in the wheel picker
  */
-export type WheelPickerOption = {
+export type WheelPickerOption<T extends WheelPickerValue = string> = {
   /** The value that will be returned when this option is selected */
-  value: string;
+  value: T;
   /** The content displayed for this option */
   label: ReactNode;
 };
@@ -25,16 +30,16 @@ export type WheelPickerClassNames = {
 /**
  * Props for the WheelPicker component
  */
-export type WheelPickerProps = {
+export type WheelPickerProps<T extends WheelPickerValue = string> = {
   /** Initial value of the picker when uncontrolled */
-  defaultValue?: string;
+  defaultValue?: T;
   /** Current value of the picker when controlled */
-  value?: string;
+  value?: T;
   /** Callback fired when the selected value changes */
-  onValueChange?: (value: string) => void;
+  onValueChange?: (value: T) => void;
 
   /** Array of options to display in the wheel */
-  options: WheelPickerOption[];
+  options: WheelPickerOption<T>[];
   /** Whether the wheel should loop infinitely */
   infinite?: boolean;
   /** The number of options visible on the circular ring, must be a multiple of 4 */


### PR DESCRIPTION
Hi, this PR addresses issue #93 





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds generic support for WheelPicker option values, enabling number values alongside strings. Updates types and exports in react-wheel-picker and aligns the web component.

- **New Features**
  - Introduced WheelPickerValue (string | number).
  - Made WheelPickerOption and WheelPickerProps generic with a default of string.
  - Updated WheelPicker to accept a generic T and tightened type safety in rendering and selection.
  - Exported WheelPickerProps and WheelPickerValue for external use.

<sup>Written for commit 717a38e378f5a4959e130700bf6af31f144003c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





