### PR TITLE
feat(sponsors): add shadcnstudio as a new sponsor in README and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This project is proudly supported by:
 
 [![Vercel OSS Program](https://assets.chanhdai.com/images/vercel-oss-program-2025.svg?t=1762229330)](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
 
+<a href="https://shadcnstudio.com"><img src="https://assets.chanhdai.com/images/shadcnstudio.svg?t=1766506647" alt="shadcnstudio.com" height="40" /></a>
+
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.
 
 ## Star History

--- a/apps/web/src/app/(app)/sponsors/page.tsx
+++ b/apps/web/src/app/(app)/sponsors/page.tsx
@@ -1,6 +1,8 @@
 import { HeartIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { VercelOSSProgramBadge } from "@/components/vercel-oss-badge";
+import { cn } from "@/lib/utils";
 
 export default function SponsorsPage() {
   return (
@@ -28,7 +30,108 @@ export default function SponsorsPage() {
         </Button>
       </div>
 
-      <div className="grid gap-4 border-t border-dashed p-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"></div>
+      <div className="border-t border-dashed p-4">
+        <div className="mb-4 font-medium">Organization Sponsors</div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <SponsorCard href="https://vercel.com/oss?utm_source=react-wheel-picker&utm_medium=web">
+            <VercelOSSProgramBadge className="h-6" />
+          </SponsorCard>
+
+          <SponsorCard href="https://shadcnstudio.com">
+            <div className="flex items-center gap-2.5">
+              <svg
+                width="1em"
+                height="1em"
+                viewBox="0 0 328 329"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className="size-7 shrink-0"
+              >
+                <rect
+                  y="0.5"
+                  width="328"
+                  height="328"
+                  rx="164"
+                  fill="black"
+                  className="dark:fill-white"
+                />
+                <path
+                  d="M165.018 72.3008V132.771C165.018 152.653 148.9 168.771 129.018 168.771H70.2288"
+                  stroke="white"
+                  strokeWidth="20"
+                  className="dark:stroke-black"
+                />
+                <path
+                  d="M166.627 265.241L166.627 204.771C166.627 184.889 182.744 168.771 202.627 168.771L261.416 168.771"
+                  stroke="white"
+                  strokeWidth="20"
+                  className="dark:stroke-black"
+                />
+                <line
+                  x1="238.136"
+                  y1="98.8184"
+                  x2="196.76"
+                  y2="139.707"
+                  stroke="white"
+                  strokeWidth="20"
+                  className="dark:stroke-black"
+                />
+                <line
+                  x1="135.688"
+                  y1="200.957"
+                  x2="94.3128"
+                  y2="241.845"
+                  stroke="white"
+                  strokeWidth="20"
+                  className="dark:stroke-black"
+                />
+                <line
+                  x1="133.689"
+                  y1="137.524"
+                  x2="92.5566"
+                  y2="96.3914"
+                  stroke="white"
+                  strokeWidth="20"
+                  className="dark:stroke-black"
+                />
+                <line
+                  x1="237.679"
+                  y1="241.803"
+                  x2="196.547"
+                  y2="200.671"
+                  stroke="white"
+                  strokeWidth="20"
+                  className="dark:stroke-black"
+                />
+              </svg>
+
+              <div className="flex flex-col gap-1">
+                <span className="text-sm leading-none font-semibold text-foreground">
+                  shadcnstudio.com
+                </span>
+                <span className="text-xs leading-none text-muted-foreground">
+                  shadcn blocks & templates
+                </span>
+              </div>
+            </div>
+          </SponsorCard>
+        </div>
+      </div>
     </div>
+  );
+}
+
+function SponsorCard({ className, ...props }: React.ComponentProps<"a">) {
+  return (
+    <a
+      className={cn(
+        "flex items-center justify-center rounded-md border p-8 shadow-xs transition-colors hover:bg-accent/30",
+        className,
+      )}
+      target="_blank"
+      rel="noopener"
+      {...props}
+    />
   );
 }

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -16,21 +16,101 @@ export function Header() {
     <header className="sticky top-0 z-50 flex h-16 items-center border-b bg-background/90 px-4 backdrop-blur-md">
       <BrandContextMenu>
         <Link
-          className="flex items-center gap-2 text-lg leading-none font-bold tracking-tight"
+          className="mr-2 flex items-center gap-2 text-lg leading-none font-bold tracking-tight lg:mr-8"
           href="/"
         >
           <Mark className="size-8" />
-          <span className="max-sm:hidden">React Wheel Picker</span>
+          <span className="max-lg:hidden">React Wheel Picker</span>
         </Link>
       </BrandContextMenu>
-
-      <div className="ml-2 sm:ml-8" />
 
       <DesktopNav />
 
       <div className="flex-1" />
 
       <div className="flex items-center gap-1">
+        <a
+          href="https://shadcnstudio.com"
+          target="_blank"
+          rel="noopener"
+          className="mr-1 flex items-center gap-2.5 rounded-md bg-zinc-50 px-2.5 py-2 transition-colors duration-300 hover:bg-zinc-100 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+        >
+          <svg
+            width="1em"
+            height="1em"
+            viewBox="0 0 328 329"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="size-5 shrink-0 sm:size-7"
+          >
+            <rect
+              y="0.5"
+              width="328"
+              height="328"
+              rx="164"
+              fill="black"
+              className="dark:fill-white"
+            />
+            <path
+              d="M165.018 72.3008V132.771C165.018 152.653 148.9 168.771 129.018 168.771H70.2288"
+              stroke="white"
+              strokeWidth="20"
+              className="dark:stroke-black"
+            />
+            <path
+              d="M166.627 265.241L166.627 204.771C166.627 184.889 182.744 168.771 202.627 168.771L261.416 168.771"
+              stroke="white"
+              strokeWidth="20"
+              className="dark:stroke-black"
+            />
+            <line
+              x1="238.136"
+              y1="98.8184"
+              x2="196.76"
+              y2="139.707"
+              stroke="white"
+              strokeWidth="20"
+              className="dark:stroke-black"
+            />
+            <line
+              x1="135.688"
+              y1="200.957"
+              x2="94.3128"
+              y2="241.845"
+              stroke="white"
+              strokeWidth="20"
+              className="dark:stroke-black"
+            />
+            <line
+              x1="133.689"
+              y1="137.524"
+              x2="92.5566"
+              y2="96.3914"
+              stroke="white"
+              strokeWidth="20"
+              className="dark:stroke-black"
+            />
+            <line
+              x1="237.679"
+              y1="241.803"
+              x2="196.547"
+              y2="200.671"
+              stroke="white"
+              strokeWidth="20"
+              className="dark:stroke-black"
+            />
+          </svg>
+
+          <div className="flex flex-col gap-1 max-sm:hidden">
+            <span className="text-sm leading-none font-semibold text-foreground">
+              shadcnstudio.com
+            </span>
+            <span className="text-xs leading-none text-muted-foreground">
+              shadcn blocks & templates
+            </span>
+          </div>
+        </a>
+
         <Button
           className="gap-1.5 has-[>svg]:px-2"
           variant="ghost"

--- a/packages/react-wheel-picker/README.md
+++ b/packages/react-wheel-picker/README.md
@@ -24,4 +24,6 @@ This project is proudly supported by:
 
 [![Vercel OSS Program](https://assets.chanhdai.com/images/vercel-oss-program-2025.svg?t=1762229330)](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
 
+<a href="https://shadcnstudio.com"><img src="https://assets.chanhdai.com/images/shadcnstudio.svg?t=1766506647" alt="shadcnstudio.com" height="40" /></a>
+
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.


### PR DESCRIPTION
Add shadcnstudio.com as a sponsor in the README files and the sponsors page. Include their logo and link to their website. Update the header to display a link to shadcnstudio.com with their logo and description.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added shadcnstudio.com as a new sponsor across the README and app UI. Displays their logo and link in the header and sponsors page for better visibility.

- **New Features**
  - README.md and package README: add shadcnstudio logo and link.
  - Sponsors page: new Organization Sponsors grid with reusable SponsorCard; includes shadcnstudio card and Vercel OSS Program badge.
  - Header: add shadcnstudio link with logo and short description; minor spacing and visibility tweaks.

<sup>Written for commit 136a7ec9cb2548e3f3a714da0f60cef75fd3558e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

