### PR TITLE
fix(README.md): update sponsor images for Vercel and shadcnstudio to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ Licensed under the [MIT license](./LICENSE).
 
 This project is proudly supported by:
 
-[![Vercel OSS Program](https://assets.chanhdai.com/images/vercel-oss-program-2025.svg?t=1762229330)](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
-
-[![shadcnstudio.com](https://assets.chanhdai.com/images/shadcnstudio.svg?t=1766507207)](https://shadcnstudio.com)
+[![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025.svg?v=1#gh-light-mode-only)](https://vercel.com/blog/summer-2025-oss-program#gh-light-mode-only) [![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025-dark.svg?v=1#gh-dark-mode-only)](https://vercel.com/blog/summer-2025-oss-program#gh-dark-mode-only) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio.svg?v=1#gh-light-mode-only)](https://shadcnstudio.com#gh-light-mode-only) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio-dark.svg?v=1#gh-dark-mode-only)](https://shadcnstudio.com#gh-dark-mode-only)
 
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.
 

--- a/packages/react-wheel-picker/README.md
+++ b/packages/react-wheel-picker/README.md
@@ -22,8 +22,6 @@ Licensed under the [MIT license](./LICENSE).
 
 This project is proudly supported by:
 
-[![Vercel OSS Program](https://assets.chanhdai.com/images/vercel-oss-program-2025.svg?t=1762229330)](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
-
-[![shadcnstudio.com](https://assets.chanhdai.com/images/shadcnstudio.svg?t=1766507207)](https://shadcnstudio.com)
+[![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025.svg?v=1)](https://vercel.com/blog/summer-2025-oss-program) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio.svg?v=1)](https://shadcnstudio.com)
 
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.


### PR DESCRIPTION
…use new URLs and improve visibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update sponsor badges in README.md and packages/react-wheel-picker/README.md to new image URLs. Adds separate light and dark images in the root README and uses versioned asset URLs to improve visibility and avoid stale caching.

<sup>Written for commit f8ae087776ee020c01258b0ef4ded639c53b37ea. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

