### PR TITLE
feat(sponsors): add individual sponsors section and related types to …

### DIFF
--- a/apps/web/src/app/(app)/showcases/page.tsx
+++ b/apps/web/src/app/(app)/showcases/page.tsx
@@ -6,11 +6,11 @@ import { SHOWCASES } from "@/data/showcases";
 export default function ShowcasesPage() {
   return (
     <div className="relative min-h-dvh max-w-screen overflow-x-hidden">
-      <h1 className="mt-12 mb-2 text-center text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-12 mb-2 text-center text-3xl font-semibold tracking-tight">
         Showcases
       </h1>
 
-      <p className="mb-6 text-center text-lg text-balance text-muted-foreground sm:text-xl">
+      <p className="mx-4 mb-6 text-center text-balance text-muted-foreground">
         A collection of projects built with React Wheel Picker.
       </p>
 

--- a/apps/web/src/app/(app)/sponsors/data.ts
+++ b/apps/web/src/app/(app)/sponsors/data.ts
@@ -1,0 +1,11 @@
+import type { Sponsor } from "./types";
+
+export const INDIVIDUAL_SPONSORS: Sponsor[] = [
+  {
+    type: "individual",
+    name: "David Haz",
+    tagline: "React Bits",
+    website: "https://github.com/DavidHDev",
+    avatar: "https://avatars.githubusercontent.com/u/48634587?v=4",
+  },
+];

--- a/apps/web/src/app/(app)/sponsors/page.tsx
+++ b/apps/web/src/app/(app)/sponsors/page.tsx
@@ -1,18 +1,21 @@
 import { HeartIcon } from "lucide-react";
+import Image from "next/image";
 
 import { Button } from "@/components/ui/button";
 import { VercelOSSProgramBadge } from "@/components/vercel-oss-badge";
 import { cn } from "@/lib/utils";
 
+import { INDIVIDUAL_SPONSORS } from "./data";
+
 export default function SponsorsPage() {
   return (
     <div className="relative min-h-dvh max-w-screen overflow-x-hidden">
-      <h1 className="mt-12 mb-2 text-center text-3xl font-bold tracking-tight sm:text-4xl">
+      <h1 className="mt-12 mb-2 text-center text-3xl font-semibold tracking-tight">
         Support <span className="block sm:hidden" />
         React Wheel Picker
       </h1>
 
-      <p className="mx-4 mb-6 text-center text-lg text-balance text-muted-foreground sm:text-xl">
+      <p className="mx-4 mb-6 text-center text-balance text-muted-foreground">
         Your sponsorship means a lot to open-source projects, including React
         Wheel Picker.
       </p>
@@ -30,8 +33,8 @@ export default function SponsorsPage() {
         </Button>
       </div>
 
-      <div className="border-t border-dashed p-4">
-        <div className="mb-4 font-medium">Organization Sponsors</div>
+      <div className="space-y-4 border-t border-dashed p-4">
+        <h2 className="font-mono text-xs">Organization Sponsors</h2>
 
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           <SponsorCard href="https://vercel.com/oss?utm_source=react-wheel-picker&utm_medium=web">
@@ -116,6 +119,38 @@ export default function SponsorsPage() {
               </div>
             </div>
           </SponsorCard>
+        </div>
+
+        <h2 className="font-mono text-xs">Individual Sponsors</h2>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {INDIVIDUAL_SPONSORS.map((item) => (
+            <SponsorCard
+              key={item.name}
+              href={item.website}
+              className="justify-start p-4"
+            >
+              <div className="grid grid-cols-[auto_1fr] items-center gap-x-3">
+                <div className="relative row-span-2 size-8 shrink-0">
+                  <Image
+                    className="size-8 rounded-full select-none"
+                    src={item.avatar}
+                    alt={item.name}
+                    width={32}
+                    height={32}
+                    unoptimized
+                  />
+                  <div className="pointer-events-none absolute inset-0 rounded-full ring-1 ring-black/10 ring-inset dark:ring-white/15" />
+                </div>
+                <div className="truncate text-sm leading-4 font-semibold text-foreground">
+                  {item.name}
+                </div>
+                <div className="translate-y-px truncate text-xs leading-4 text-muted-foreground">
+                  {item.tagline}
+                </div>
+              </div>
+            </SponsorCard>
+          ))}
         </div>
       </div>
     </div>

--- a/apps/web/src/app/(app)/sponsors/types.ts
+++ b/apps/web/src/app/(app)/sponsors/types.ts
@@ -1,0 +1,12 @@
+type SponsorBase = {
+  name: string;
+  website: string;
+};
+
+export type IndividualSponsor = SponsorBase & {
+  type: "individual";
+  avatar: string;
+  tagline: string;
+};
+
+export type Sponsor = IndividualSponsor;


### PR DESCRIPTION
…SponsorsPage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an Individual Sponsors section to the Sponsors page with typed data and avatar cards, so we can recognize personal backers. Also aligned page typography for consistency across Sponsors and Showcases.

- **New Features**
  - Defined IndividualSponsor type and Sponsor union in sponsors/types.ts.
  - Added INDIVIDUAL_SPONSORS in sponsors/data.ts (seeded with David Haz).
  - Rendered an Individual Sponsors grid in SponsorsPage using SponsorCard and next/image.
  - Updated headings and copy styles in SponsorsPage and ShowcasesPage for consistent typography.

<sup>Written for commit c5eb4b4d2e421310c160de3a433eaf3d79ff5456. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

