### PR TITLE
fix(sponsors): update shadcnstudio links to include UTM parameters fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Licensed under the [MIT license](./LICENSE).
 
 This project is proudly supported by:
 
-[![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025.svg?v=1#gh-light-mode-only)](https://vercel.com/blog/summer-2025-oss-program#gh-light-mode-only) [![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025-dark.svg?v=1#gh-dark-mode-only)](https://vercel.com/blog/summer-2025-oss-program#gh-dark-mode-only) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio.svg?v=1#gh-light-mode-only)](https://shadcnstudio.com#gh-light-mode-only) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio-dark.svg?v=1#gh-dark-mode-only)](https://shadcnstudio.com#gh-dark-mode-only)
+[![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025.svg?v=1#gh-light-mode-only)](https://vercel.com/blog/summer-2025-oss-program#gh-light-mode-only) [![Vercel OSS Program](https://assets.chanhdai.com/images/sponsors/vercel-oss-program-2025-dark.svg?v=1#gh-dark-mode-only)](https://vercel.com/blog/summer-2025-oss-program#gh-dark-mode-only) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio.svg?v=1#gh-light-mode-only)](https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github#gh-light-mode-only) [![shadcnstudio.com](https://assets.chanhdai.com/images/sponsors/shadcnstudio-dark.svg?v=1#gh-dark-mode-only)](https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github#gh-dark-mode-only)
 
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.
 

--- a/apps/web/src/app/(app)/sponsors/page.tsx
+++ b/apps/web/src/app/(app)/sponsors/page.tsx
@@ -41,7 +41,7 @@ export default function SponsorsPage() {
             <VercelOSSProgramBadge className="h-6" />
           </SponsorCard>
 
-          <SponsorCard href="https://shadcnstudio.com">
+          <SponsorCard href="https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github">
             <div className="flex items-center gap-2.5">
               <svg
                 width="1em"

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -30,7 +30,7 @@ export function Header() {
 
       <div className="flex items-center gap-1">
         <a
-          href="https://shadcnstudio.com"
+          href="https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github"
           target="_blank"
           rel="noopener"
           className="mr-1 flex items-center gap-2.5 rounded-md bg-zinc-50 px-2.5 py-2 transition-colors duration-300 hover:bg-zinc-100 dark:bg-zinc-900 dark:hover:bg-zinc-800"


### PR DESCRIPTION
…r tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added UTM parameters (utm_source=chandai, utm_medium=banner, utm_campaign=github) to all shadcnstudio links to enable referral tracking from the README, header, and Sponsors page.

<sup>Written for commit ad263f340a087f932a2a8445d8639b4dcdc507de. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

