### PR TITLE
feat(sponsors): add tier property to SponsorBase and update ShadcnStu…

### DIFF
--- a/apps/web/src/app/(app)/sponsors/page.tsx
+++ b/apps/web/src/app/(app)/sponsors/page.tsx
@@ -41,7 +41,10 @@ export default function SponsorsPage() {
             <VercelOSSProgramBadge className="h-6" />
           </SponsorCard>
 
-          <SponsorCard href="https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github">
+          <SponsorCard
+            className="relative pb-10"
+            href="https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github"
+          >
             <div className="flex items-center gap-2.5">
               <svg
                 width="1em"
@@ -118,6 +121,10 @@ export default function SponsorsPage() {
                 </span>
               </div>
             </div>
+
+            <span className="absolute right-0 bottom-0 rounded-tl-sm border-t border-l border-dashed px-1.5 py-0.5 font-mono text-xs font-medium text-muted-foreground">
+              Silver Sponsor
+            </span>
           </SponsorCard>
         </div>
 

--- a/apps/web/src/app/(app)/sponsors/types.ts
+++ b/apps/web/src/app/(app)/sponsors/types.ts
@@ -1,6 +1,9 @@
+export type SponsorTier = "silver" | "gold" | "platinum";
+
 type SponsorBase = {
   name: string;
   website: string;
+  tier?: SponsorTier;
 };
 
 export type IndividualSponsor = SponsorBase & {


### PR DESCRIPTION
…dio card layout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added sponsor tiering to the data model and updated the ShadcnStudio card to display a “Silver Sponsor” badge.

- **New Features**
  - Added SponsorTier type ("silver" | "gold" | "platinum") and optional tier field to SponsorBase.
  - Updated ShadcnStudio SponsorCard layout and added a bottom-right “Silver Sponsor” badge.

<sup>Written for commit 5add088bf842be7a0d4a120ddbfcf272a81a2b19. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

