### PR TITLE
style(sponsors): adjust padding and position for ShadcnStudio sponsor…

### DIFF
--- a/apps/web/src/app/(app)/sponsors/page.tsx
+++ b/apps/web/src/app/(app)/sponsors/page.tsx
@@ -42,7 +42,7 @@ export default function SponsorsPage() {
           </SponsorCard>
 
           <SponsorCard
-            className="relative pb-10"
+            className="relative"
             href="https://shadcnstudio.com?utm_source=chandai&utm_medium=banner&utm_campaign=github"
           >
             <div className="flex items-center gap-2.5">
@@ -122,7 +122,7 @@ export default function SponsorsPage() {
               </div>
             </div>
 
-            <span className="absolute right-0 bottom-0 rounded-tl-sm border-t border-l border-dashed px-1.5 py-0.5 font-mono text-xs font-medium text-muted-foreground">
+            <span className="absolute right-2 bottom-1 text-xs font-medium text-muted-foreground">
               Silver Sponsor
             </span>
           </SponsorCard>


### PR DESCRIPTION
… card label

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the ShadcnStudio sponsor card label for cleaner alignment and readability. Removed extra bottom padding on the card and simplified the label from a bordered badge to a plain text label positioned at right-2/bottom-1.

<sup>Written for commit 5685d14835ae9232bddaa4d740af01eca891ce9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

