### PR TITLE
ci(release.yml): comment out NPM_TOKEN and switch to OIDC for npm aut…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,7 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Use OIDC for npm authentication instead of NPM_TOKEN
+          NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           NODE_ENV: "production"


### PR DESCRIPTION
…hentication

Switching to OIDC for npm authentication improves security and aligns with recommended practices. The NPM_TOKEN is commented out to prevent its use, and a reference to the relevant issue is added for context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use GitHub OIDC for npm authentication in the release workflow, replacing the NPM_TOKEN secret. NPM_TOKEN is commented out and set to an empty string per Changesets guidance to improve security and reduce secret management.

<sup>Written for commit 86ef633bfc64813236617ea4ff8510c2d76dcbb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

