### PR TITLE
chore(release.yml): pin changesets/action to a specific commit for st…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Create release PR or publish to NPM
         id: changesets
-        uses: changesets/action@v1
+        # uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: "chore(release): version packages"
           commit: "chore(release): version packages"


### PR DESCRIPTION
…ability

Pin the changesets/action to a specific commit hash to ensure consistent behavior and avoid potential issues with future updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned changesets/action in .github/workflows/release.yml to a specific commit (v1.5.3) to ensure consistent release behavior. This avoids unexpected changes from future action updates.

<sup>Written for commit ccdb6e8d7e51c2e1ba3863d3ea5d5da0ad12bbf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

