### PR TITLE
chore(release.yml): comment out commitMode to use default commit method

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           commit: "chore(release): version packages"
           version: node .github/changeset-version.mjs
           publish: npx changeset publish
-          commitMode: github-api
+          # commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Commented out commitMode: github-api in the release workflow to use the default Changesets commit method.

This simplifies the release step and avoids relying on the GitHub API for commits.

<sup>Written for commit 1dcd0a521f040743c08ce8b3d931be64714178fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

