### PR TITLE
ci(release.yml): move permissions to top level for better organization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+  contents: write
+  id-token: write
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -29,7 +30,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.16.0
+          registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
+
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
 
       - name: Install NPM dependencies
         run: pnpm install
@@ -39,8 +44,7 @@ jobs:
 
       - name: Create release PR or publish to NPM
         id: changesets
-        # uses: changesets/action@v1
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
+        uses: changesets/action@v1
         with:
           title: "chore(release): version packages"
           commit: "chore(release): version packages"
@@ -51,5 +55,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Use OIDC for npm authentication instead of NPM_TOKEN
-          NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+          # NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           NODE_ENV: "production"


### PR DESCRIPTION
ci(release.yml): add registry-url to setup-node for npm registry access

ci(release.yml): update npm to latest for OIDC support

ci(release.yml): switch changesets action to stable version v1 for reliability

ci(release.yml): comment out NPM_TOKEN to use OIDC for npm authentication

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release workflow to OIDC-based npm publishing and move permissions to the workflow top level to improve security and clarity. Also standardize the changesets action to v1 for reliability.

- **Refactors**
  - Moved workflow permissions to the top level.
  - Switched to changesets/action@v1.

- **Dependencies**
  - Set registry-url in setup-node for npm.
  - Updated npm to latest and use OIDC instead of NPM_TOKEN.

<sup>Written for commit c347a1f57cc2cedc902df295e9e5d8cb6b66ae1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

