### PR TITLE
chore(workflow): update Node.js version to 22.20.0 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
           version: 10.7.0
           run_install: false
 
-      - name: Setup Node.js 20.16.0
+      - name: Setup Node.js 22.20.0
         uses: actions/setup-node@v4
         with:
-          node-version: 20.16.0
+          node-version: 22.20.0
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
@@ -50,10 +50,6 @@ jobs:
           commit: "chore(release): version packages"
           version: node .github/changeset-version.mjs
           publish: npx changeset publish
-          # commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Use OIDC for npm authentication instead of NPM_TOKEN
-          # NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           NODE_ENV: "production"


### PR DESCRIPTION
Update Node.js version to ensure compatibility with the latest features and security updates. Remove commented-out lines related to NPM_TOKEN to clean up the workflow configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the release workflow to use Node.js 22.20.0 for compatibility and security. Cleaned up the config by removing commented NPM_TOKEN lines; no functional change to publishing.

<sup>Written for commit 0fd37549be2ea7745cc13f5ad77b39cc208be017. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

