### PR TITLE
docs: update README and page titles to include type-ahead search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ iOS-like wheel picker for React with smooth inertia scrolling and infinite loop 
 - 🖱️ Mouse drag and scroll support for desktop
 - 🔄 Infinite loop scrolling
 - 🎨 Unstyled components for complete style customization
+- ⌨️ Full keyboard navigation and type-ahead search
 - ⚡️ Easy installation via shadcn CLI
 
 Check out the live demo: https://react-wheel-picker.chanhdai.com

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -37,7 +37,7 @@ const featuredItems = [
   },
   {
     icon: KeyboardIcon,
-    title: "Full keyboard navigation",
+    title: "Full keyboard navigation and type-ahead search",
   },
   {
     icon: Icons.shadcn,
@@ -224,7 +224,7 @@ function FeaturedItem({
 function PraiseCard({ avatar, name, description, content, refLink }: Praise) {
   return (
     <a
-      className="block"
+      className="block rounded-md"
       href={refLink}
       target="_blank"
       rel="noopener"

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -135,7 +135,7 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    @apply border-border;
+    @apply border-border outline-ring/50;
   }
 
   body {

--- a/packages/react-wheel-picker/README.md
+++ b/packages/react-wheel-picker/README.md
@@ -6,6 +6,7 @@ iOS-like wheel picker for React with smooth inertia scrolling and infinite loop 
 - 🖱️ Mouse drag and scroll support for desktop
 - 🔄 Infinite loop scrolling
 - 🎨 Unstyled components for complete style customization
+- ⌨️ Full keyboard navigation and type-ahead search
 - ⚡️ Easy installation via shadcn CLI
 
 Check out the live demo: https://react-wheel-picker.chanhdai.com


### PR DESCRIPTION
style: enhance global styles with outline for better accessibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated READMEs and the homepage feature title to include type-ahead search in keyboard navigation. Improved accessibility with a global focus outline and rounded Praise card links.

<sup>Written for commit c929c5bdc3a5b3d1f9a03f6e4b5b3417f2717520. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

