### PR TITLE
style(docs): add focus style for WheelPickerDemo to improve accessibi…

### DIFF
--- a/apps/web/src/content/docs/getting-started.mdx
+++ b/apps/web/src/content/docs/getting-started.mdx
@@ -215,6 +215,10 @@ export function WheelPickerDemo() {
   background-color: #f4f4f5;
   color: #09090b;
 }
+
+[data-rwp-highlight-wrapper][data-rwp-focused] {
+  box-shadow: inset 0 0 0 2px #d4d4d8;
+}
 ```
 
 ```tsx


### PR DESCRIPTION
…lity and user experience

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a visible focus state to the WheelPickerDemo in the Getting Started docs so keyboard users can see focus clearly. Applies an inset 2px gray box-shadow to the focused highlight wrapper to improve accessibility.

<sup>Written for commit d9632369bf2cbe180342f64d12d5e3cc47253d85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

