### PR TITLE
chore: add Legacy Wheel Picker showcase to the list

### DIFF
--- a/apps/web/src/data/showcases.ts
+++ b/apps/web/src/data/showcases.ts
@@ -1,5 +1,9 @@
 export const SHOWCASES = [
   {
+    name: "Legacy Wheel Picker",
+    href: "https://sabraman.ru/components/legacy-wheel-picker",
+  },
+  {
     name: "Wigggle UI",
     href: "https://wigggle-ui.vercel.app",
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the Legacy Wheel Picker to the website’s showcases list so it’s discoverable in the gallery, linking to https://sabraman.ru/components/legacy-wheel-picker.

<sup>Written for commit ee1f0c78cf171e50179455a88e41154b57194dd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

