### PR TITLE
chore: update sponsors URLs to point to open-source pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ This project is proudly supported by:
         </a>
       </td>
       <td>
-        <a href="https://openpanel.dev?utm_source=react-wheel-picker#gh-light-mode-only">
+        <a href="https://openpanel.dev/open-source?utm_source=react-wheel-picker#gh-light-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/openpanel.svg?v=1#gh-light-mode-only"
             alt="OpenPanel"
           />
         </a>
-        <a href="https://openpanel.dev?utm_source=react-wheel-picker#gh-dark-mode-only">
+        <a href="https://openpanel.dev/open-source?utm_source=react-wheel-picker#gh-dark-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/openpanel-dark.svg?v=1#gh-dark-mode-only"
             alt="OpenPanel"
@@ -73,13 +73,13 @@ This project is proudly supported by:
         </a>
       </td>
       <td>
-        <a href="https://www.mintlify.com?utm_source=react-wheel-picker#gh-light-mode-only">
+        <a href="https://www.mintlify.com/oss-program?utm_source=react-wheel-picker#gh-light-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/mintlify.svg?v=1#gh-light-mode-only"
             alt="Mintlify"
           />
         </a>
-        <a href="https://www.mintlify.com?utm_source=react-wheel-picker#gh-dark-mode-only">
+        <a href="https://www.mintlify.com/oss-program?utm_source=react-wheel-picker#gh-dark-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/mintlify-dark.svg?v=1#gh-dark-mode-only"
             alt="Mintlify"

--- a/apps/web/src/data/sponsors.tsx
+++ b/apps/web/src/data/sponsors.tsx
@@ -70,7 +70,7 @@ export const SPONSORS: Sponsor[] = [
   },
   {
     name: "OpenPanel",
-    url: "https://openpanel.dev?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
+    url: "https://openpanel.dev/open-source?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
     logo: function (props: React.ComponentProps<"svg">) {
       return (
         <svg fill="currentColor" viewBox="0 0 320 96" {...props}>
@@ -88,7 +88,7 @@ export const SPONSORS: Sponsor[] = [
   },
   {
     name: "Mintlify",
-    url: "https://www.mintlify.com?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
+    url: "https://www.mintlify.com/oss-program?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
     logo: function (props: React.ComponentProps<"svg">) {
       return (
         <svg viewBox="0 0 320 96" fill="currentColor" {...props}>
@@ -105,7 +105,7 @@ export const SPONSORS: Sponsor[] = [
   },
   // {
   //   name: "Termius",
-  //   url: "https://termius.com?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
+  //   url: "https://termius.com/opensource?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
   //   logo: function (props: React.ComponentProps<"svg">) {
   //     return (
   //       <svg viewBox="0 0 320 96" fill="none" {...props}>

--- a/packages/react-wheel-picker/README.md
+++ b/packages/react-wheel-picker/README.md
@@ -40,7 +40,7 @@ This project is proudly supported by:
         </a>
       </td>
       <td>
-        <a href="https://openpanel.dev?utm_source=react-wheel-picker">
+        <a href="https://openpanel.dev/open-source?utm_source=react-wheel-picker">
           <img
             src="https://assets.chanhdai.com/images/sponsors/openpanel.svg?v=1"
             alt="OpenPanel"
@@ -48,7 +48,7 @@ This project is proudly supported by:
         </a>
       </td>
       <td>
-        <a href="https://www.mintlify.com?utm_source=react-wheel-picker">
+        <a href="https://www.mintlify.com/oss-program?utm_source=react-wheel-picker">
           <img
             src="https://assets.chanhdai.com/images/sponsors/mintlify.svg?v=1"
             alt="Mintlify"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update sponsor links to point to each sponsor’s open-source page for clearer attribution and context. Changes touch the root README, `packages/react-wheel-picker` README, and `apps/web` sponsors data; no functional impact.

- **Refactors**
  - OpenPanel: `openpanel.dev` → `openpanel.dev/open-source` (keeps UTM; light/dark anchors updated)
  - Mintlify: `mintlify.com` → `mintlify.com/oss-program` (keeps UTM; light/dark anchors updated)
  - Termius (commented): `termius.com` → `termius.com/opensource`

<sup>Written for commit f9e72d60c64245df4224cf2a3fbef929542ed011. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

