### PR TITLE
docs: add affiliate tracking parameters to sponsor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ This project is proudly supported by:
     </tr>
     <tr>
       <td>
-        <a href="https://shadcncraft.com?utm_source=react-wheel-picker#gh-light-mode-only">
+        <a href="https://shadcncraft.com?atp=ncdai&utm_source=react-wheel-picker#gh-light-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/shadcncraft.svg?v=2#gh-light-mode-only"
             alt="shadcncraft"
           />
         </a>
-        <a href="https://shadcncraft.com?utm_source=react-wheel-picker#gh-dark-mode-only">
+        <a href="https://shadcncraft.com?atp=ncdai&utm_source=react-wheel-picker#gh-dark-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/shadcncraft-dark.svg?v=1#gh-dark-mode-only"
             alt="shadcncraft"
@@ -134,13 +134,13 @@ This project is proudly supported by:
         </a>
       </td>
       <td>
-        <a href="https://www.shadcnblocks.com?utm_source=react-wheel-picker#gh-light-mode-only">
+        <a href="https://www.shadcnblocks.com?via=ncdai&utm_source=react-wheel-picker#gh-light-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/shadcnblocks.svg?v=1#gh-light-mode-only"
             alt="Shadcnblocks"
           />
         </a>
-        <a href="https://www.shadcnblocks.com?utm_source=react-wheel-picker#gh-dark-mode-only">
+        <a href="https://www.shadcnblocks.com?via=ncdai&utm_source=react-wheel-picker#gh-dark-mode-only">
           <img
             src="https://assets.chanhdai.com/images/sponsors/shadcnblocks-dark.svg?v=1#gh-dark-mode-only"
             alt="Shadcnblocks"

--- a/apps/web/src/data/sponsors.tsx
+++ b/apps/web/src/data/sponsors.tsx
@@ -150,7 +150,7 @@ export const SPONSORS: Sponsor[] = [
   },
   {
     name: "shadcncraft",
-    url: "https://shadcncraft.com?utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
+    url: "https://shadcncraft.com?atp=ncdai&utm_source=react-wheel-picker&utm_medium=sponsor&utm_campaign=website",
     logo: function (props: React.ComponentProps<"svg">) {
       return (
         <svg viewBox="0 0 320 96" {...props}>
@@ -177,7 +177,7 @@ export const SPONSORS: Sponsor[] = [
   },
   {
     name: "Shadcnblocks",
-    url: "https://www.shadcnblocks.com",
+    url: "https://www.shadcnblocks.com?via=ncdai",
     logo: function (props: React.ComponentProps<"svg">) {
       return (
         <svg viewBox="0 0 320 96" fill="currentColor" {...props}>

--- a/packages/react-wheel-picker/README.md
+++ b/packages/react-wheel-picker/README.md
@@ -80,7 +80,7 @@ This project is proudly supported by:
     </tr>
     <tr>
       <td>
-        <a href="https://shadcncraft.com?utm_source=react-wheel-picker">
+        <a href="https://shadcncraft.com?atp=ncdai&utm_source=react-wheel-picker">
           <img
             src="https://assets.chanhdai.com/images/sponsors/shadcncraft.svg?v=2"
             alt="shadcncraft"
@@ -88,7 +88,7 @@ This project is proudly supported by:
         </a>
       </td>
       <td>
-        <a href="https://www.shadcnblocks.com?utm_source=react-wheel-picker">
+        <a href="https://www.shadcnblocks.com?via=ncdai&utm_source=react-wheel-picker">
           <img
             src="https://assets.chanhdai.com/images/sponsors/shadcnblocks.svg?v=1"
             alt="Shadcnblocks"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add affiliate tracking parameters to sponsor links to attribute referrals across docs and the website. Updated `README.md`, `packages/react-wheel-picker/README.md`, and `apps/web` sponsors data to use `atp=ncdai` for `shadcncraft` and `via=ncdai` for `shadcnblocks`, preserving existing UTM params where present.

<sup>Written for commit 16d7c7eece04659e7f85ff9e306abdc7b8de0d72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

