### PR TITLE
feat: upgrade pnpm version to 11.1.1 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.7.0
+          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js 22.20.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `pnpm` to 11.1.1 in the release GitHub Actions workflow. Keeps CI on v11 and picks up recent fixes and improvements.

<sup>Written for commit 776b2e5ab9f74d82b92e183c13d32b3cba30980f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

