### PR TITLE
docs(README): replace badge services with shieldcn.dev for

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
-# [React Wheel Picker](https://react-wheel-picker.chanhdai.com) &middot; [![GitHub License](https://img.shields.io/github/license/ncdai/react-wheel-picker)](https://github.com/ncdai/react-wheel-picker/blob/main/LICENSE) [![NPM Version](https://img.shields.io/npm/v/%40ncdai%2Freact-wheel-picker)](https://www.npmjs.com/package/@ncdai/react-wheel-picker) [![NPM Downloads](https://img.shields.io/npm/dy/%40ncdai%2Freact-wheel-picker)](https://www.npmjs.com/package/@ncdai/react-wheel-picker) ![GitHub Repo Views](https://gitviews.com/repo/ncdai/react-wheel-picker.svg?label=views&style=flat&label-color=%23555&color=%234c1) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/ncdai/react-wheel-picker/release.yml)](https://github.com/ncdai/react-wheel-picker/actions/workflows/release.yml)
+# [React Wheel Picker](https://react-wheel-picker.chanhdai.com)
+
+<p>
+  <a href="https://github.com/ncdai/react-wheel-picker"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/ncdai/react-wheel-picker/license.svg?variant=outline&amp;font=geist" /><img alt="license" src="https://shieldcn.dev/github/ncdai/react-wheel-picker/license.svg?variant=outline&amp;mode=light&amp;font=geist" /></picture></a>
+  <a href="https://www.npmjs.com/package/@ncdai/react-wheel-picker"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/@ncdai/react-wheel-picker.svg?variant=outline&amp;font=geist" /><img alt="version" src="https://shieldcn.dev/npm/@ncdai/react-wheel-picker.svg?variant=outline&amp;mode=light&amp;font=geist" /></picture></a>
+  <a href="https://www.npmjs.com/package/@ncdai/react-wheel-picker"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/dw/@ncdai/react-wheel-picker.svg?variant=outline&amp;font=geist" /><img alt="downloads" src="https://shieldcn.dev/npm/dw/@ncdai/react-wheel-picker.svg?variant=outline&amp;mode=light&amp;font=geist" /></picture></a>
+  <a href="https://github.com/ncdai/react-wheel-picker/actions"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/ncdai/react-wheel-picker/ci.svg?variant=outline&amp;font=geist" /><img alt="CI" src="https://shieldcn.dev/github/ncdai/react-wheel-picker/ci.svg?variant=outline&amp;mode=light&amp;font=geist" /></picture></a>
+  <a href="https://github.com/ncdai/react-wheel-picker"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/views/repo/ncdai/react-wheel-picker.svg?base=8541&amp;variant=outline&amp;font=geist" /><img alt="repo views" src="https://shieldcn.dev/views/repo/ncdai/react-wheel-picker.svg?base=8541&amp;variant=outline&amp;mode=light&amp;font=geist" /></picture></a>
+</p>
 
 Backed by [▲Vercel OSS Program](https://vercel.com/blog/summer-2025-oss-program#react-wheel-picker)
 
 iOS-like wheel picker for React with smooth inertia scrolling and infinite loop support.
 
-- Natural touch scrolling with smooth inertia effect
-- Mouse drag and scroll support for desktop
-- Infinite loop scrolling
-- Unstyled components for complete style customization
-- Full keyboard navigation and type-ahead search
-- Easy installation via shadcn CLI
+- Natural touch scrolling with smooth inertia, mouse drag and scroll for desktop.
+- Infinite loop scrolling.
+- Unstyled core for complete style customization.
+- Full keyboard navigation and type-ahead search.
 
 → Check out the live demo: https://react-wheel-picker.chanhdai.com
 
@@ -30,9 +36,9 @@ Please read the [contributing guide](/CONTRIBUTING.md).
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=ncdai/react-wheel-picker)](https://github.com/ncdai/react-wheel-picker/graphs/contributors)
-
-> Made with [contrib.rocks](https://contrib.rocks)
+<p>
+  <a href="https://github.com/ncdai/react-wheel-picker/graphs/contributors"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/contributors/ncdai/react-wheel-picker.svg?title=false&amp;size=48&amp;align=left&amp;mode=dark&amp;font=geist&amp;watermark=true" /><img alt="contributors" src="https://shieldcn.dev/contributors/ncdai/react-wheel-picker.svg?title=false&amp;size=48&amp;align=left&amp;mode=light&amp;font=geist&amp;watermark=true" /></picture></a>
+</p>
 
 ## License
 
@@ -211,10 +217,8 @@ This project is proudly supported by:
 
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.
 
-## NPM Downloads
-
-![npm downloads](https://www.npm.bet/svg?q=%40ncdai%2Freact-wheel-picker&timeRange=last-year&grouping=week)
-
 ## Star History
 
-[![Star History](https://starchart.cc/ncdai/react-wheel-picker.svg?variant=adaptive&line=%2300d3f3)](https://starchart.cc/ncdai/react-wheel-picker)
+<p>
+  <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/chart/github/stars/ncdai/react-wheel-picker.svg?font=geist" /><img alt="chart" src="https://shieldcn.dev/chart/github/stars/ncdai/react-wheel-picker.svg?mode=light&amp;font=geist" /></picture>
+</p>


### PR DESCRIPTION
consistent styling and dark mode support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched README badges to shieldcn.dev for consistent styling and dark mode support. Replaced license, `@ncdai/react-wheel-picker` npm version/downloads, CI, repo views, contributors, and star chart images; removed the old NPM downloads chart and tightened feature bullets.

<sup>Written for commit de95726a5fa41a39b0b4e93f8f324bff9a373f63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ncdai/react-wheel-picker/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

