### PR TITLE
docs: remove star history section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,3 @@ This project is proudly supported by:
 </table>
 
 > Using this package at work? [Sponsor me](https://github.com/sponsors/ncdai) to help with support and maintenance.
-
-## Star history
-
-<p>
-  <picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/chart/github/stars/ncdai/react-wheel-picker.svg?font=geist&amp;theme=cyan" /><img alt="chart" src="https://shieldcn.dev/chart/github/stars/ncdai/react-wheel-picker.svg?mode=light&amp;font=geist&amp;theme=cyan" /></picture>
-</p>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the Star history section from README to simplify the docs and eliminate external chart embeds.

<sup>Written for commit 59c1e945b08aa44c1997410e79e9fc3e3c16aec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ncdai/react-wheel-picker/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

