### PR TITLE
docs: add changeset for README update

### DIFF
--- a/.changeset/silly-kings-double.md
+++ b/.changeset/silly-kings-double.md
@@ -1,0 +1,5 @@
+---
+"@ncdai/react-wheel-picker": patch
+---
+
+Update README


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a changeset to publish a patch release of `@ncdai/react-wheel-picker` for the README update. This ensures the docs change appears in the changelog without altering runtime behavior.

- Produces a patch version; no code, API, or runtime changes.
- No migration or testing required; merging will trigger the release.

<sup>Written for commit 70108797dfe8f2cd1d19644789709d7996542379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ncdai/react-wheel-picker/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

