### PR TITLE
ci: use github-api commit mode for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           commit: "chore(release): version packages"
           version: node .github/changeset-version.mjs
           publish: npx changeset publish
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: "production"


### PR DESCRIPTION
Commits created via the GitHub API are GPG-signed by GitHub, so the release PR passes the "Commits must have verified signatures" rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use GitHub API commit mode for `changesets/action` so release commits are GPG-signed by GitHub and pass the "Commits must have verified signatures" rule. Previously commits were created via local Git and could be unverified; now `commitMode: github-api` ensures verified signatures on the release PR.

- Change is limited to `.github/workflows/release.yml`: add `commitMode: github-api` to the `changesets/action` step.
- Requires `secrets.GITHUB_TOKEN` with contents: write (already set). Expect commits from `github-actions[bot]` with verified signatures. No runtime or package changes.

<sup>Written for commit c2bc77deed286b45f9ce82978692ac77890c0d04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ncdai/react-wheel-picker/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

